### PR TITLE
[FIX] Use Module#prepend instead of alias_method_chain

### DIFF
--- a/lib/active_admin/xls/engine.rb
+++ b/lib/active_admin/xls/engine.rb
@@ -12,7 +12,7 @@ module ActiveAdmin
 
         ActiveAdmin::ResourceDSL.send :include, ActiveAdmin::Xls::DSL
         ActiveAdmin::Resource.send :include, ActiveAdmin::Xls::ResourceExtension
-        ActiveAdmin::ResourceController.send :include, ActiveAdmin::Xls::ResourceControllerExtension
+        ActiveAdmin::ResourceController.send :prepend, ActiveAdmin::Xls::ResourceControllerExtension
       end
     end
   end

--- a/lib/active_admin/xls/resource_controller_extension.rb
+++ b/lib/active_admin/xls/resource_controller_extension.rb
@@ -2,13 +2,11 @@ module ActiveAdmin
   module Xls
     module ResourceControllerExtension
       def self.included(base)
-        base.send :alias_method_chain, :per_page, :xls
-        base.send :alias_method_chain, :index, :xls
         base.send :respond_to, :xls
       end
 
-      def index_with_xls(&block)
-        index_without_xls do |format|
+      def index(&block)
+        super do |format|
           block.call format if block_given?
 
           format.xls do
@@ -21,12 +19,12 @@ module ActiveAdmin
       end
 
       # patching per_page to use the CSV record max for pagination when the format is xls
-      def per_page_with_xls
+      def per_page
         if request.format ==  Mime::Type.lookup_by_extension(:xls)
           return respond_to?(:max_per_page, true) ? max_per_page : active_admin_config.max_per_page
         end
 
-        per_page_without_xls
+        super
       end
 
       # Returns a filename for the xls file using the collection_name


### PR DESCRIPTION
- rails 5.1 has deprecated `alias_method_chain`. 
- it is working on my rails 5.1 branch locally. download XLS in active admin still seems to work lol. anything I can test?

